### PR TITLE
Add hmm_model.py for stock predictions

### DIFF
--- a/hmm_model.py
+++ b/hmm_model.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pandas as pd
+from hmmlearn import hmm
+from sklearn.preprocessing import StandardScaler
+
+def preprocess_data(stock_data):
+    """
+    Cleans and prepares stock data for training.
+    """
+    # Drop any NaN values
+    stock_data.dropna(inplace=True)
+    
+    # Feature engineering: calculate daily returns
+    stock_data['Returns'] = stock_data['Close'].pct_change()
+    
+    # Drop rows with NaN values created by pct_change
+    stock_data.dropna(inplace=True)
+    
+    # Standardize the features
+    scaler = StandardScaler()
+    stock_data['Returns'] = scaler.fit_transform(stock_data['Returns'].values.reshape(-1, 1))
+    
+    return stock_data
+
+def train_model(preprocessed_data):
+    """
+    Trains the Hidden Markov Model using preprocessed data.
+    """
+    # Extract the 'Returns' as training data
+    X = preprocessed_data['Returns'].values.reshape(-1, 1)
+    
+    # Define the HMM parameters
+    n_components = 4  # Number of hidden states
+    model = hmm.GaussianHMM(n_components=n_components, covariance_type="diag", n_iter=1000)
+    
+    # Fit the model
+    model.fit(X)
+    
+    return model
+
+def predict(model, preprocessed_data):
+    """
+    Makes predictions using the trained model and preprocessed data.
+    """
+    # Predict hidden states for the data
+    hidden_states = model.predict(preprocessed_data['Returns'].values.reshape(-1, 1))
+    
+    # Calculate the mean of the returns for each state
+    means = np.array(model.means_)
+    predicted_returns = means[hidden_states]
+    
+    # Convert predicted returns to prices (this is a simplification)
+    predictions = np.exp(predicted_returns.cumsum())
+    
+    return predictions


### PR DESCRIPTION
This pull request adds the missing `hmm_model.py` file to the repository, implementing the necessary functions for the web application's prediction process as outlined in the README.md.

- **Implements `preprocess_data` function**: Cleans and prepares stock data for training by dropping NaN values, calculating daily returns, and standardizing the features.
- **Implements `train_model` function**: Trains the Hidden Markov Model using the preprocessed data, setting up the model with 4 hidden states and fitting it to the 'Returns' feature of the data.
- **Implements `predict` function**: Utilizes the trained model to make predictions on the preprocessed data, predicting hidden states and calculating the mean returns for each state to convert them into price predictions.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nvp159/Hidden-Makov-Model?shareId=b23fc1a3-1f25-4efa-bf54-fb9e303a3c06).