### PR TITLE
Enhance HMM Model with Multiple Predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Our project highlights include:
 
 6. **Enhanced UI with Charts:** The UI now displays data through beautifully colored charts and simple, elegant components. This includes a chart for historic data and different UI components to show predictions from various models elegantly.
 
+### New Capabilities of `hmm_model.py`
+
+The `hmm_model.py` script has been significantly enhanced to include all possible HMM models and predictions from `HMM_Nifty50.ipynb`, allowing for multiple predictions from a single function call. This new functionality enables the application to generate predictions using multiple HMM configurations, including different numbers of hidden states and covariance types.
+
+### Generating Predictions with `generate_all_predictions`
+
+To utilize the new capabilities of `hmm_model.py`, a function named `generate_all_predictions` has been added. This function iterates through multiple HMM configurations and generates predictions for each, providing a comprehensive analysis of potential market movements. The predictions are structured in a JSON response, making it easy to integrate with the `app.py` `make_prediction` route.
+
 ### Getting Started with the Web Application
 
 To set up and run the web application, follow these steps:

--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 from flask import Flask, request, jsonify
-from hmm_model import preprocess_data, train_model, predict, fetch_data
+from hmm_model import preprocess_data, train_model, predict, fetch_data, generate_all_predictions
 
 app = Flask(__name__)
 
@@ -21,10 +21,8 @@ def make_prediction():
     stock_data = fetch_data(ticker, interval)
     if stock_data.empty:
         return jsonify({'error': 'No data found for the given ticker and interval'}), 404
-    preprocessed_data = preprocess_data(stock_data)
-    model = train_model(preprocessed_data)
-    predictions = predict(model, preprocessed_data)
-    return jsonify({'predictions': predictions.tolist()})
+    predictions = generate_all_predictions(stock_data)
+    return jsonify({'predictions': predictions})
 
 if __name__ == '__main__':
     app.run(debug=True)


### PR DESCRIPTION
This pull request enhances the `hmm_model.py` script to include all possible HMM models and predictions from `HMM_Nifty50.ipynb`, enabling multiple predictions from a single function call. Additionally, it updates the `app.py` to utilize these new capabilities.

- **Introduces `generate_all_predictions` function in `hmm_model.py`**: This function iterates through multiple HMM configurations, including different numbers of hidden states and covariance types, to generate predictions for each. It returns a structured JSON object containing predictions from all models, facilitating easy integration with `app.py`.
- **Modifies `train_model` function in `hmm_model.py`**: Now accepts `n_components` and `covariance_type` as arguments, allowing for training with various HMM configurations.
- **Updates `app.py` `make_prediction` route**: Alters the route to call `generate_all_predictions` instead of the previous `train_model` and `predict` functions, enabling the return of predictions from multiple HMM models in a single API call.
- **Documentation updates in `README.md`**: Reflects the new capabilities of `hmm_model.py`, including instructions on how to use the `generate_all_predictions` function and the structure of the JSON response from the `make_prediction` route in `app.py`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nvp159/Hidden-Makov-Model?shareId=189d962c-9152-416c-923c-8e07748b09ee).